### PR TITLE
[update]ci 新增支持 qemu-riscv

### DIFF
--- a/.github/workflows/RT-AK_Linux_Utest_CI.yml
+++ b/.github/workflows/RT-AK_Linux_Utest_CI.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         git clone https://github.com/Lebhoryi/QemuAutoBSP.git $TEST_BSP_ROOT
 
-    - name: Prepare Arm BSP
+    - name: Prepare RISC-V BSP
       if: ${{ matrix.legs.QEMU_ARCH == 'riscv64' && success() }}
       run: |
         git clone https://github.com/EdgeAIWithRTT/qemu-riscv-virt64.git $TEST_BSP_ROOT

--- a/.github/workflows/RT-AK_Linux_Utest_CI.yml
+++ b/.github/workflows/RT-AK_Linux_Utest_CI.yml
@@ -5,8 +5,17 @@ on: [push, pull_request]
 jobs:
   RT-AK-Github-Actions:
     runs-on: ubuntu-18.04
+    name: ${{ matrix.legs.UTEST }}
+    strategy:
+      fail-fast: false
+      matrix:
+        legs:
+          - {UTEST: "stm32/components/utest", RTT_BSP: "../AutoSTM32BSP", QEMU_ARCH: "arm", QEMU_MACHINE: "vexpress-a9"}
+          - {UTEST: "riscv64/kernel/mem", RTT_BSP: "../AutoK210BSP", QEMU_ARCH: "riscv64", QEMU_MACHINE: "virt"}
     env:
-      TEST_BSP_ROOT: ../AutoTestBsp
+      TEST_BSP_ROOT: ${{ matrix.legs.RTT_BSP }}
+      TEST_QEMU_ARCH: ${{ matrix.legs.QEMU_ARCH }}
+      TEST_QEMU_MACHINE: ${{ matrix.legs.QEMU_MACHINE }}
 
     steps:
     - name: Checkout
@@ -31,14 +40,30 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Install Arm ToolChains
+      if: ${{ matrix.legs.QEMU_ARCH == 'arm' && success() }}
       run: |
-        wget -q https://github.com/RT-Thread/toolchains-ci/releases/download/arm-2017q2-v6/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 
-        sudo tar xjf gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -C /opt
-        /opt/gcc-arm-none-eabi-6-2017-q2-update/bin/arm-none-eabi-gcc --version
+        wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+        sudo tar xjf gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 -C /opt
+        /opt/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-gcc --version
+        echo "RTT_EXEC_PATH=/opt/gcc-arm-none-eabi-10-2020-q4-major/bin" >> $GITHUB_ENV
 
-    - name: Prepare BSP
+    - name: Install RISC-V ToolChains
+      if: ${{ matrix.legs.QEMU_ARCH == 'riscv64' && success() }}
+      run: |
+        wget -q https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
+        sudo tar zxf riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz -C /opt
+        /opt/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14/bin/riscv64-unknown-elf-gcc --version
+        echo "RTT_EXEC_PATH=/opt/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14/bin" >> $GITHUB_ENV
+
+    - name: Prepare Arm BSP
+      if: ${{ matrix.legs.QEMU_ARCH == 'arm' && success() }}
       run: |
         git clone https://github.com/Lebhoryi/QemuAutoBSP.git $TEST_BSP_ROOT
+
+    - name: Prepare Arm BSP
+      if: ${{ matrix.legs.QEMU_ARCH == 'riscv64' && success() }}
+      run: |
+        git clone https://github.com/EdgeAIWithRTT/qemu-riscv-virt64.git $TEST_BSP_ROOT
 
     - name: Run RT-AK
       run: |
@@ -48,7 +73,6 @@ jobs:
     
     - name: Build BSP
       run: |
-        export RTT_EXEC_PATH=/opt/gcc-arm-none-eabi-6-2017-q2-update/bin
         scons --pyconfig-silent -C $TEST_BSP_ROOT
         scons -j$(nproc) -C $TEST_BSP_ROOT
 
@@ -57,6 +81,6 @@ jobs:
       run: |
         git clone https://github.com/EdgeAIWithRTT/UtestRunner.git
         pushd UtestRunner
-        python3 qemu_runner.py --elf ../$TEST_BSP_ROOT/rtthread.elf
+        python3 qemu_runner.py --system $TEST_QEMU_ARCH --machine $TEST_QEMU_MACHINE --elf ../$TEST_BSP_ROOT/rtthread.elf
         cat rtt_console.log
         popd

--- a/.github/workflows/RT-AK_Linux_Utest_CI.yml
+++ b/.github/workflows/RT-AK_Linux_Utest_CI.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   RT-AK-Github-Actions:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: ${{ matrix.legs.UTEST }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## 拉取/合并请求描述：

[

1. RT-AK ci 新增支持 qemu-riscv

]

### 当前拉取/合并请求的状态：

必须选择一项:

- [ ] 本拉取/合并请求是一个草稿版本
- [x] 本拉取/合并请求是一个成熟版本

### 代码质量：

我在这个拉取/合并请求中已经考虑了:

- [x] 已经仔细查看过代码改动的对比
- [x] 代码风格正确，包括缩进空格，命名及其他风格
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或
- [x] 对难懂代码均提供对应的注释
- [x] 本拉取/合并请求代码是高质量的
- [x] 本拉取/合并符合 RT-Thread 代码规范
