### PR TITLE
添加__cpluscplus宏, 修复C++兼容性

### DIFF
--- a/RT-AK/rt_ai_lib/include/rt_ai.h
+++ b/RT-AK/rt_ai_lib/include/rt_ai.h
@@ -10,6 +10,10 @@
 
 #ifndef _RT_AI_H
 #define _RT_AI_H
+#ifdef __cplusplus
+extern "C"{
+#endif
+
 #include <rt_ai_def.h>
 #include <rt_ai_common.h>
 
@@ -19,4 +23,8 @@ rt_err_t rt_ai_run(rt_ai_t ai, void (*callback)(void * arg), void *arg);
 rt_ai_t  rt_ai_find(const char *name);
 rt_ai_buffer_t* rt_ai_output(rt_ai_t ai, rt_uint32_t index);
 rt_err_t rt_ai_config(rt_ai_t ai, int cmd, rt_ai_buffer_t *arg);
+
+#ifdef __cplusplus
+}
 #endif
+#endif // _RT_AI_H

--- a/RT-AK/rt_ai_lib/include/rt_ai.h
+++ b/RT-AK/rt_ai_lib/include/rt_ai.h
@@ -10,6 +10,7 @@
 
 #ifndef _RT_AI_H
 #define _RT_AI_H
+
 #ifdef __cplusplus
 extern "C"{
 #endif

--- a/RT-AK/rt_ai_lib/include/rt_ai_common.h
+++ b/RT-AK/rt_ai_lib/include/rt_ai_common.h
@@ -14,7 +14,9 @@
 
 #include <rt_ai_def.h>
 #include <aiconfig.h>
-
+#ifdef __cplusplus
+extern "C"{
+#endif
 #define RT_AI_FLAG_INITED   0x01
 #define RT_AI_FLAG_LOADED   0X02
 #define RT_AI_FLAG_RUN      0x04
@@ -102,4 +104,7 @@ if (!(_expr))                                                                   
 #define rt_ai_del(_ptr)             rt_ai_free(_ptr)
 
 void rt_ai_allocate_buffer(rt_ai_t ai, rt_ai_buffer_t *buf);
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/RT-AK/rt_ai_lib/include/rt_ai_common.h
+++ b/RT-AK/rt_ai_lib/include/rt_ai_common.h
@@ -14,9 +14,11 @@
 
 #include <rt_ai_def.h>
 #include <aiconfig.h>
+
 #ifdef __cplusplus
 extern "C"{
 #endif
+
 #define RT_AI_FLAG_INITED   0x01
 #define RT_AI_FLAG_LOADED   0X02
 #define RT_AI_FLAG_RUN      0x04
@@ -104,6 +106,7 @@ if (!(_expr))                                                                   
 #define rt_ai_del(_ptr)             rt_ai_free(_ptr)
 
 void rt_ai_allocate_buffer(rt_ai_t ai, rt_ai_buffer_t *buf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/RT-AK/rt_ai_lib/include/rt_ai_core.h
+++ b/RT-AK/rt_ai_lib/include/rt_ai_core.h
@@ -13,8 +13,16 @@
 #include <rt_ai_def.h>
 #include <rt_ai_common.h>
 
+#ifdef __cplusplus
+extern "C"{
+#endif
 rt_ai_core_t rt_ai_core_register(struct rt_ai_core *object, enum rt_ai_obj_type type, const char *name);
 rt_ai_core_t rt_ai_core_find(const char *name, rt_uint8_t type);
 void rt_ai_core_detach(rt_ai_core_t object);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif
 

--- a/RT-AK/rt_ai_lib/include/rt_ai_core.h
+++ b/RT-AK/rt_ai_lib/include/rt_ai_core.h
@@ -16,6 +16,7 @@
 #ifdef __cplusplus
 extern "C"{
 #endif
+
 rt_ai_core_t rt_ai_core_register(struct rt_ai_core *object, enum rt_ai_obj_type type, const char *name);
 rt_ai_core_t rt_ai_core_find(const char *name, rt_uint8_t type);
 void rt_ai_core_detach(rt_ai_core_t object);
@@ -23,6 +24,5 @@ void rt_ai_core_detach(rt_ai_core_t object);
 #ifdef __cplusplus
 }
 #endif
-
 #endif
 

--- a/RT-AK/rt_ai_lib/include/rt_ai_def.h
+++ b/RT-AK/rt_ai_lib/include/rt_ai_def.h
@@ -12,6 +12,7 @@
 #define __RT_AI_DEF__
 #include <rtthread.h>
 #include <aiconfig.h>
+
 #ifdef __cplusplus
 extern "C"{
 #endif
@@ -146,5 +147,4 @@ struct rt_ai_record
 #ifdef __cplusplus
 }
 #endif
-
 #endif

--- a/RT-AK/rt_ai_lib/include/rt_ai_def.h
+++ b/RT-AK/rt_ai_lib/include/rt_ai_def.h
@@ -12,6 +12,9 @@
 #define __RT_AI_DEF__
 #include <rtthread.h>
 #include <aiconfig.h>
+#ifdef __cplusplus
+extern "C"{
+#endif
 
 #define RT_AI_NULL          NULL
 #define RT_AI_OK            0
@@ -138,5 +141,10 @@ struct rt_ai_record
     struct rt_ai_core      parent;
     rt_ai_uint32_t  record;
 };
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/RT-AK/rt_ai_lib/include/rt_ai_runtime.h
+++ b/RT-AK/rt_ai_lib/include/rt_ai_runtime.h
@@ -11,7 +11,9 @@
 #ifndef __RT_AI_RUNTIME_H__
 #define __RT_AI_RUNTIME_H__
 #include <rt_ai_def.h>
-
+#ifdef __cplusplus
+extern "C"{
+#endif
 void run_done(void *arg);
 void run_entry(rt_ai_t ai);
 rt_ai_record_t rt_ai_record_find(const char *name);
@@ -26,5 +28,7 @@ rt_ai_timestamp_t statistic_time_interval(const char *name);
 
 #define STATISTIC_TIME_INTERVAL(_name) \
     statistic_time_interval(_name)
-
+#ifdef __cplusplus
+}
+#endif
 #endif //end

--- a/RT-AK/rt_ai_lib/include/rt_ai_runtime.h
+++ b/RT-AK/rt_ai_lib/include/rt_ai_runtime.h
@@ -11,9 +11,11 @@
 #ifndef __RT_AI_RUNTIME_H__
 #define __RT_AI_RUNTIME_H__
 #include <rt_ai_def.h>
+
 #ifdef __cplusplus
 extern "C"{
 #endif
+
 void run_done(void *arg);
 void run_entry(rt_ai_t ai);
 rt_ai_record_t rt_ai_record_find(const char *name);
@@ -28,6 +30,7 @@ rt_ai_timestamp_t statistic_time_interval(const char *name);
 
 #define STATISTIC_TIME_INTERVAL(_name) \
     statistic_time_interval(_name)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
在多个头文件中添加__cpluscplus宏, 修复C++支持.

```c
#ifdef __cplusplus
extern "C"{
#endif

...

#ifdef __cplusplus
}
#endif
```