### PR TITLE
[HUST CSE][rt_ai_mpython.c]fix: In line 63,wrong conditional judgment, change the duplicate info.input_n to output_n

### DIFF
--- a/model-zoo/project/tensorflow2_models/K210_projects/k210_le&alex/mpy_rt_ai/rt_ai_mpython.c
+++ b/model-zoo/project/tensorflow2_models/K210_projects/k210_le&alex/mpy_rt_ai/rt_ai_mpython.c
@@ -60,7 +60,7 @@ STATIC mp_obj_t py_rt_ai_init(size_t n_args, const mp_obj_t *pos_args, mp_map_t 
     if(stat){
         mp_raise_OSError(stat);
     }
-    if(!handle->info.input_n && !handle->info.input_n){
+    if(!handle->info.input_n && !handle->info.output_n){
         handle->info.input_n = inputs_size(handle); __debug(handle->info.input_n);
         handle->info.output_n = outputs_size(handle); __debug(handle->info.output_n);
 


### PR DESCRIPTION
第63行条件判断语句错误 if(!handle->info.input_n && !handle->info.input_n)，重复判断 !handle->info.input_n，该条件原意对infoinput_n和info.input_n进行判断，由于失误重复对infoinput_n进行了判断，应将后一个改为 !handle->info.output_n