### PR TITLE
[HUST CSE]Modified the issue of using a variable without assigning a value

### DIFF
--- a/model-zoo/project/tensorflow2_models/K210_projects/k210_le&alex/rt-thread/components/utilities/zmodem/zcore.c
+++ b/model-zoo/project/tensorflow2_models/K210_projects/k210_le&alex/rt-thread/components/utilities/zmodem/zcore.c
@@ -337,6 +337,7 @@ static rt_int16_t zrec_data32(rt_uint8_t *buf, rt_int16_t len)
 
     crc_cnt = 0;   crc = 0xffffffffL;
     Rxcount = 0;
+    p = buf;
     while (buf <= p+len)
     {
         if ((res = zread_byte()) & ~0377)


### PR DESCRIPTION
第340行指针p在while循环之前未进行赋值造成错误，根据前后的函数，应使p=buf